### PR TITLE
Remove incompatible hack for Rails 6.1 upgrade

### DIFF
--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -4,7 +4,6 @@ module Crummy
   class StandardRenderer
     include ActionView::Helpers::UrlHelper
     include ActionView::Helpers::TagHelper unless self.included_modules.include?(ActionView::Helpers::TagHelper)
-    ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.merge([:itemscope].to_set)
 
     # Render the list of crumbs as either html or xml
     #


### PR DESCRIPTION
This was [added 9 years ago "for google SEO"](https://github.com/zachinglis/crummy/commit/5e4d5beca6faf52f455b8013af91140ce290fe74) which cannot possibly matter for our manage dashboard.

This was always a problem, it's just that now Rails is protecting itself. This is the error raised when attempting to view manage on the Rails 6.1 branch:

```
web          |
web          | ActionView::Template::Error (can't modify frozen Hash: {"allowfullscreen"=>true, "allowpaymentrequest"=>true, "async"=>true, "autofocus"=>true, "autoplay"=>true, "checked"=>true, "compact"=>true, "controls"=>true, "declare"=>true, "default"=>true, "defaultchecked"=>true, "defaultmuted"=>true, "defaultselected"=>true, "defer"=>true, "disabled"=>true, "enabled"=>true, "formnovalidate"=>true, "hidden"=>true, "indeterminate"=>true, "inert"=>true, "ismap"=>true, "itemscope"=>true, "loop"=>true, "multiple"=>true, "muted"=>true, "nohref"=>true, "nomodule"=>true, "noresize"=>true, "noshade"=>true, "novalidate"=>true, "nowrap"=>true, "open"=>true, "pauseonexit"=>true, "playsinline"=>true, "readonly"=>true, "required"=>true, "reversed"=>true, "scoped"=>true, "seamless"=>true, "selected"=>true, "sortable"=>true, "truespeed"=>true, "typemustmatch"=>true, "visible"=>true, :allowfullscreen=>true, :allowpaymentrequest=>true, :async=>true, :autofocus=>true, :autoplay=>true, :checked=>true, :compact=>true, :controls=>true, :declare=>true, :default=>true, :defaultchecked=>true, :defaultmuted=>true, :defaultselected=>true, :defer=>true, :disabled=>true, :enabled=>true, :formnovalidate=>true, :hidden=>true, :indeterminate=>true, :inert=>true, :ismap=>true, :itemscope=>true, :loop=>true, :multiple=>true, :muted=>true, :nohref=>true, :nomodule=>true, :noresize=>true, :noshade=>true, :novalidate=>true, :nowrap=>true, :open=>true, :pauseonexit=>true, :playsinline=>true, :readonly=>true, :required=>true, :reversed=>true, :scoped=>true, :seamless=>true, :selected=>true, :sortable=>true, :truespeed=>true, :typemustmatch=>true, :visible=>true}):
web          |     1: .adminsimple-title-column
web          |     2:   %nav#adminsimple_breadcrumb
web          |     3:     = render_crumbs(separator: ' / ')
web          |     4:   %h1= title
web          |     5:
web          |     6: .adminsimple-action-column
web          |
web          | /Users/cory-boyd/.asdf/installs/ruby/2.7.2/lib/ruby/2.7.0/set.rb:424:in `update'
web          | /Users/cory-boyd/.asdf/installs/ruby/2.7.2/lib/ruby/2.7.0/set.rb:424:in `merge'
web          | /Users/cory-boyd/code/crummy/lib/crummy/standard_renderer.rb:7:in `<class:StandardRenderer>'
web          | /Users/cory-boyd/code/crummy/lib/crummy/standard_renderer.rb:4:in `<module:Crummy>'
web          | /Users/cory-boyd/code/crummy/lib/crummy/standard_renderer.rb:3:in `<main>'
```